### PR TITLE
added named detectors for BGO crystals

### DIFF
--- a/COSISMEX.BGO_activated.det
+++ b/COSISMEX.BGO_activated.det
@@ -114,6 +114,15 @@ BGO_Coinc_sideX.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideX.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideX.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_sideX.Named BGO_Coinc_sideX_1
+BGO_Coinc_sideX_1.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE1
+
+BGO_Coinc_sideX.Named BGO_Coinc_sideX_2
+BGO_Coinc_sideX_2.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE2
+
+BGO_Coinc_sideX.Named BGO_Coinc_sideX_3
+BGO_Coinc_sideX_3.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE3
+
 Voxel3D     BGO_Coinc_sideX_neg
 BGO_Coinc_sideX_neg.DetectorVolume     BGOsideXneg_ACTIVE
 BGO_Coinc_sideX_neg.SensitiveVolume    BGOsideXneg_ACTIVE
@@ -123,6 +132,15 @@ BGO_Coinc_sideX_neg.TriggerThreshold   80.0
 BGO_Coinc_sideX_neg.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideX_neg.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideX_neg.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_1
+BGO_Coinc_sideX_neg_1.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE1
+
+BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_2
+BGO_Coinc_sideX_neg_2.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE2
+
+BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_3
+BGO_Coinc_sideX_neg_3.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE3
 
 Voxel3D     BGO_Coinc_sideY
 BGO_Coinc_sideY.DetectorVolume     BGOsideY_ACTIVE
@@ -134,6 +152,15 @@ BGO_Coinc_sideY.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideY.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideY.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_sideY.Named BGO_Coinc_sideY_1
+BGO_Coinc_sideY_1.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE1
+
+BGO_Coinc_sideY.Named BGO_Coinc_sideY_2
+BGO_Coinc_sideY_2.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE2
+
+BGO_Coinc_sideY.Named BGO_Coinc_sideY_3
+BGO_Coinc_sideY_3.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE3
+
 Voxel3D     BGO_Coinc_sideY_neg
 BGO_Coinc_sideY_neg.DetectorVolume     BGOsideYneg_ACTIVE
 BGO_Coinc_sideY_neg.SensitiveVolume    BGOsideYneg_ACTIVE
@@ -143,6 +170,15 @@ BGO_Coinc_sideY_neg.TriggerThreshold   80.0
 BGO_Coinc_sideY_neg.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideY_neg.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideY_neg.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_1
+BGO_Coinc_sideY_neg_1.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE1
+
+BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_2
+BGO_Coinc_sideY_neg_2.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE2
+
+BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_3
+BGO_Coinc_sideY_neg_3.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE3
 
 Trigger BgoVeto_bottom1
 BgoVeto_bottom1.Veto false

--- a/COSISMEX.BGO_activated.det
+++ b/COSISMEX.BGO_activated.det
@@ -12,6 +12,9 @@ BGO_Coinc_bottom1.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom1.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom1.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_bottom1.Named ACS_Z0_0
+ACS_Z0_0.Assign WorldVolume.ShieldedTelescope.BGObotCrystal1_ACTIVE
+
 Voxel3D     BGO_Coinc_bottom2
 BGO_Coinc_bottom2.DetectorVolume     BGObotCrystal2_ACTIVE
 BGO_Coinc_bottom2.SensitiveVolume    BGObotCrystal2_ACTIVE
@@ -21,6 +24,9 @@ BGO_Coinc_bottom2.TriggerThreshold   80.0
 BGO_Coinc_bottom2.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom2.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom2.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_bottom2.Named ACS_Z0_1
+ACS_Z0_1.Assign WorldVolume.ShieldedTelescope.BGObotCrystal2_ACTIVE
 
 Voxel3D     BGO_Coinc_bottom3
 BGO_Coinc_bottom3.DetectorVolume     BGObotCrystal3_ACTIVE
@@ -32,6 +38,9 @@ BGO_Coinc_bottom3.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom3.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom3.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_bottom3.Named ACS_Z0_2
+ACS_Z0_2.Assign WorldVolume.ShieldedTelescope.BGObotCrystal3_ACTIVE
+
 Voxel3D     BGO_Coinc_bottom4
 BGO_Coinc_bottom4.DetectorVolume     BGObotCrystal4_ACTIVE
 BGO_Coinc_bottom4.SensitiveVolume    BGObotCrystal4_ACTIVE
@@ -41,6 +50,9 @@ BGO_Coinc_bottom4.TriggerThreshold   80.0
 BGO_Coinc_bottom4.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom4.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom4.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_bottom4.Named ACS_Z0_3
+ACS_Z0_3.Assign WorldVolume.ShieldedTelescope.BGObotCrystal4_ACTIVE
 
 Voxel3D     BGO_Coinc_bottom5
 BGO_Coinc_bottom5.DetectorVolume     BGObotCrystal5_ACTIVE
@@ -52,6 +64,9 @@ BGO_Coinc_bottom5.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom5.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom5.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_bottom5.Named ACS_Z0_4
+ACS_Z0_4.Assign WorldVolume.ShieldedTelescope.BGObotCrystal5_ACTIVE
+
 Voxel3D     BGO_Coinc_bottom6
 BGO_Coinc_bottom6.DetectorVolume     BGObotCrystal6_ACTIVE
 BGO_Coinc_bottom6.SensitiveVolume    BGObotCrystal6_ACTIVE
@@ -61,6 +76,9 @@ BGO_Coinc_bottom6.TriggerThreshold   80.0
 BGO_Coinc_bottom6.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom6.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom6.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_bottom6.Named ACS_Z1_0
+ACS_Z1_0.Assign WorldVolume.ShieldedTelescope.BGObotCrystal6_ACTIVE
 
 Voxel3D     BGO_Coinc_bottom7
 BGO_Coinc_bottom7.DetectorVolume     BGObotCrystal7_ACTIVE
@@ -72,6 +90,9 @@ BGO_Coinc_bottom7.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom7.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom7.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_bottom7.Named ACS_Z1_1
+ACS_Z1_1.Assign WorldVolume.ShieldedTelescope.BGObotCrystal7_ACTIVE
+
 Voxel3D     BGO_Coinc_bottom8
 BGO_Coinc_bottom8.DetectorVolume     BGObotCrystal8_ACTIVE
 BGO_Coinc_bottom8.SensitiveVolume    BGObotCrystal8_ACTIVE
@@ -81,6 +102,9 @@ BGO_Coinc_bottom8.TriggerThreshold   80.0
 BGO_Coinc_bottom8.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom8.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom8.NoiseThresholdEqualsTriggerThreshold true
+
+BGO_Coinc_bottom8.Named ACS_Z1_2
+ACS_Z1_2.Assign WorldVolume.ShieldedTelescope.BGObotCrystal8_ACTIVE
 
 Voxel3D     BGO_Coinc_bottom9
 BGO_Coinc_bottom9.DetectorVolume     BGObotCrystal9_ACTIVE
@@ -92,6 +116,9 @@ BGO_Coinc_bottom9.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom9.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom9.NoiseThresholdEqualsTriggerThreshold true
 
+BGO_Coinc_bottom9.Named ACS_Z1_3
+ACS_Z1_3.Assign WorldVolume.ShieldedTelescope.BGObotCrystal9_ACTIVE
+
 Voxel3D     BGO_Coinc_bottom10
 BGO_Coinc_bottom10.DetectorVolume     BGObotCrystal10_ACTIVE
 BGO_Coinc_bottom10.SensitiveVolume    BGObotCrystal10_ACTIVE
@@ -102,7 +129,8 @@ BGO_Coinc_bottom10.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_bottom10.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_bottom10.NoiseThresholdEqualsTriggerThreshold true
 
-
+BGO_Coinc_bottom10.Named ACS_Z1_4
+ACS_Z1_4.Assign WorldVolume.ShieldedTelescope.BGObotCrystal10_ACTIVE
 
 Voxel3D     BGO_Coinc_sideX
 BGO_Coinc_sideX.DetectorVolume     BGOsideX_ACTIVE
@@ -114,14 +142,14 @@ BGO_Coinc_sideX.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideX.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideX.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_sideX.Named BGO_Coinc_sideX_1
-BGO_Coinc_sideX_1.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE1
+BGO_Coinc_sideX.Named ACS_X1_0
+ACS_X1_0.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE1
 
-BGO_Coinc_sideX.Named BGO_Coinc_sideX_2
-BGO_Coinc_sideX_2.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE2
+BGO_Coinc_sideX.Named ACS_X1_1
+ACS_X1_1.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE2
 
-BGO_Coinc_sideX.Named BGO_Coinc_sideX_3
-BGO_Coinc_sideX_3.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE3
+BGO_Coinc_sideX.Named ACS_X1_2
+ACS_X1_2.Assign WorldVolume.ShieldedTelescope.BGOsideX_ACTIVE3
 
 Voxel3D     BGO_Coinc_sideX_neg
 BGO_Coinc_sideX_neg.DetectorVolume     BGOsideXneg_ACTIVE
@@ -133,14 +161,14 @@ BGO_Coinc_sideX_neg.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideX_neg.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideX_neg.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_1
-BGO_Coinc_sideX_neg_1.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE1
+BGO_Coinc_sideX_neg.Named ACS_X0_0
+ACS_X0_0.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE1
 
-BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_2
-BGO_Coinc_sideX_neg_2.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE2
+BGO_Coinc_sideX_neg.Named ACS_X1_1
+ACS_X1_1.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE2
 
-BGO_Coinc_sideX_neg.Named BGO_Coinc_sideX_neg_3
-BGO_Coinc_sideX_neg_3.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE3
+BGO_Coinc_sideX_neg.Named ACS_X0_2
+ACS_X0_2.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE3
 
 Voxel3D     BGO_Coinc_sideY
 BGO_Coinc_sideY.DetectorVolume     BGOsideY_ACTIVE
@@ -152,14 +180,14 @@ BGO_Coinc_sideY.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideY.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideY.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_sideY.Named BGO_Coinc_sideY_1
-BGO_Coinc_sideY_1.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE1
+BGO_Coinc_sideY.Named ACS_Y1_2
+ACS_Y1_2.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE1
 
-BGO_Coinc_sideY.Named BGO_Coinc_sideY_2
-BGO_Coinc_sideY_2.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE2
+BGO_Coinc_sideY.Named ACS_Y1_1
+ACS_Y1_1.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE2
 
-BGO_Coinc_sideY.Named BGO_Coinc_sideY_3
-BGO_Coinc_sideY_3.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE3
+BGO_Coinc_sideY.Named ACS_Y1_0
+BGO_Coinc_sideY_3.ACS_Y1_0 WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE3
 
 Voxel3D     BGO_Coinc_sideY_neg
 BGO_Coinc_sideY_neg.DetectorVolume     BGOsideYneg_ACTIVE
@@ -171,14 +199,14 @@ BGO_Coinc_sideY_neg.EnergyResolution   Gauss    0.0    0.0   10.0
 BGO_Coinc_sideY_neg.EnergyResolution   Gauss  100.0  100.0   10.0
 BGO_Coinc_sideY_neg.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_1
-BGO_Coinc_sideY_neg_1.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE1
+BGO_Coinc_sideY_neg.Named ACS_Y0_2
+ACS_Y0_2.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE1
 
-BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_2
-BGO_Coinc_sideY_neg_2.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE2
+BGO_Coinc_sideY_neg.Named ACS_Y0_1
+ACS_Y0_1.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE2
 
-BGO_Coinc_sideY_neg.Named BGO_Coinc_sideY_neg_3
-BGO_Coinc_sideY_neg_3.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE3
+BGO_Coinc_sideY_neg.Named ACS_Y0_0
+ACS_Y0_0.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE3
 
 Trigger BgoVeto_bottom1
 BgoVeto_bottom1.Veto false

--- a/COSISMEX.BGO_activated.det
+++ b/COSISMEX.BGO_activated.det
@@ -2,135 +2,106 @@
 # Detector information:
 
 
-Voxel3D     BGO_Coinc_bottom1
-BGO_Coinc_bottom1.DetectorVolume     BGObotCrystal1_ACTIVE
-BGO_Coinc_bottom1.SensitiveVolume    BGObotCrystal1_ACTIVE
-BGO_Coinc_bottom1.VoxelNumber        17 8 3
-BGO_Coinc_bottom1.Offset             0 0 0
-BGO_Coinc_bottom1.TriggerThreshold   80.0
-BGO_Coinc_bottom1.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom1.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom1.NoiseThresholdEqualsTriggerThreshold true
+Voxel3D     ACS_Z0_0
+ACS_Z0_0.DetectorVolume     BGObotCrystal1_ACTIVE
+ACS_Z0_0.SensitiveVolume    BGObotCrystal1_ACTIVE
+ACS_Z0_0.VoxelNumber        17 8 3
+ACS_Z0_0.Offset             0 0 0
+ACS_Z0_0.TriggerThreshold   80.0
+ACS_Z0_0.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z0_0.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z0_0.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_bottom1.Named ACS_Z0_0
-ACS_Z0_0.Assign WorldVolume.ShieldedTelescope.BGObotCrystal1_ACTIVE
+Voxel3D     ACS_Z0_1
+ACS_Z0_1.DetectorVolume     BGObotCrystal2_ACTIVE
+ACS_Z0_1.SensitiveVolume    BGObotCrystal2_ACTIVE
+ACS_Z0_1.VoxelNumber        17 6 3
+ACS_Z0_1.Offset             0 0 0
+ACS_Z0_1.TriggerThreshold   80.0
+ACS_Z0_1.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z0_1.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z0_1.NoiseThresholdEqualsTriggerThreshold true
 
-Voxel3D     BGO_Coinc_bottom2
-BGO_Coinc_bottom2.DetectorVolume     BGObotCrystal2_ACTIVE
-BGO_Coinc_bottom2.SensitiveVolume    BGObotCrystal2_ACTIVE
-BGO_Coinc_bottom2.VoxelNumber        17 6 3
-BGO_Coinc_bottom2.Offset             0 0 0
-BGO_Coinc_bottom2.TriggerThreshold   80.0
-BGO_Coinc_bottom2.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom2.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom2.NoiseThresholdEqualsTriggerThreshold true
+Voxel3D     ACS_Z0_2
+ACS_Z0_2.DetectorVolume     BGObotCrystal3_ACTIVE
+ACS_Z0_2.SensitiveVolume    BGObotCrystal3_ACTIVE
+ACS_Z0_2.VoxelNumber        17 6 3
+ACS_Z0_2.Offset             0 0 0
+ACS_Z0_2.TriggerThreshold   80.0
+ACS_Z0_2.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z0_2.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z0_2.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_bottom2.Named ACS_Z0_1
-ACS_Z0_1.Assign WorldVolume.ShieldedTelescope.BGObotCrystal2_ACTIVE
+Voxel3D     ACS_Z0_3
+ACS_Z0_3.DetectorVolume     BGObotCrystal4_ACTIVE
+ACS_Z0_3.SensitiveVolume    BGObotCrystal4_ACTIVE
+ACS_Z0_3.VoxelNumber        20 6 3
+ACS_Z0_3.Offset             0 0 0
+ACS_Z0_3.TriggerThreshold   80.0
+ACS_Z0_3.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z0_3.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z0_3.NoiseThresholdEqualsTriggerThreshold true
 
-Voxel3D     BGO_Coinc_bottom3
-BGO_Coinc_bottom3.DetectorVolume     BGObotCrystal3_ACTIVE
-BGO_Coinc_bottom3.SensitiveVolume    BGObotCrystal3_ACTIVE
-BGO_Coinc_bottom3.VoxelNumber        17 6 3
-BGO_Coinc_bottom3.Offset             0 0 0
-BGO_Coinc_bottom3.TriggerThreshold   80.0
-BGO_Coinc_bottom3.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom3.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom3.NoiseThresholdEqualsTriggerThreshold true
+Voxel3D     ACS_Z0_4
+ACS_Z0_4.DetectorVolume     BGObotCrystal5_ACTIVE
+ACS_Z0_4.SensitiveVolume    BGObotCrystal5_ACTIVE
+ACS_Z0_4.VoxelNumber        20 6 3
+ACS_Z0_4.Offset             0 0 0
+ACS_Z0_4.TriggerThreshold   80.0
+ACS_Z0_4.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z0_4.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z0_4.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_bottom3.Named ACS_Z0_2
-ACS_Z0_2.Assign WorldVolume.ShieldedTelescope.BGObotCrystal3_ACTIVE
+Voxel3D     ACS_Z1_0
+ACS_Z1_0.DetectorVolume     BGObotCrystal6_ACTIVE
+ACS_Z1_0.SensitiveVolume    BGObotCrystal6_ACTIVE
+ACS_Z1_0.VoxelNumber        20 8 3
+ACS_Z1_0.Offset             0 0 0
+ACS_Z1_0.TriggerThreshold   80.0
+ACS_Z1_0.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z1_0.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z1_0.NoiseThresholdEqualsTriggerThreshold true
 
-Voxel3D     BGO_Coinc_bottom4
-BGO_Coinc_bottom4.DetectorVolume     BGObotCrystal4_ACTIVE
-BGO_Coinc_bottom4.SensitiveVolume    BGObotCrystal4_ACTIVE
-BGO_Coinc_bottom4.VoxelNumber        20 6 3
-BGO_Coinc_bottom4.Offset             0 0 0
-BGO_Coinc_bottom4.TriggerThreshold   80.0
-BGO_Coinc_bottom4.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom4.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom4.NoiseThresholdEqualsTriggerThreshold true
+Voxel3D     ACS_Z1_1
+ACS_Z1_1.DetectorVolume     BGObotCrystal7_ACTIVE
+ACS_Z1_1.SensitiveVolume    BGObotCrystal7_ACTIVE
+ACS_Z1_1.VoxelNumber        17 6 3
+ACS_Z1_1.Offset             0 0 0
+ACS_Z1_1.TriggerThreshold   80.0
+ACS_Z1_1.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z1_1.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z1_1.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_bottom4.Named ACS_Z0_3
-ACS_Z0_3.Assign WorldVolume.ShieldedTelescope.BGObotCrystal4_ACTIVE
+Voxel3D     ACS_Z1_2
+ACS_Z1_2.DetectorVolume     BGObotCrystal8_ACTIVE
+ACS_Z1_2.SensitiveVolume    BGObotCrystal8_ACTIVE
+ACS_Z1_2.VoxelNumber        17 6 3
+ACS_Z1_2.Offset             0 0 0
+ACS_Z1_2.TriggerThreshold   80.0
+ACS_Z1_2.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z1_2.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z1_2.NoiseThresholdEqualsTriggerThreshold true
 
-Voxel3D     BGO_Coinc_bottom5
-BGO_Coinc_bottom5.DetectorVolume     BGObotCrystal5_ACTIVE
-BGO_Coinc_bottom5.SensitiveVolume    BGObotCrystal5_ACTIVE
-BGO_Coinc_bottom5.VoxelNumber        20 6 3
-BGO_Coinc_bottom5.Offset             0 0 0
-BGO_Coinc_bottom5.TriggerThreshold   80.0
-BGO_Coinc_bottom5.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom5.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom5.NoiseThresholdEqualsTriggerThreshold true
+Voxel3D     ACS_Z1_3
+ACS_Z1_3.DetectorVolume     BGObotCrystal9_ACTIVE
+ACS_Z1_3.SensitiveVolume    BGObotCrystal9_ACTIVE
+ACS_Z1_3.VoxelNumber        20 6 3
+ACS_Z1_3.Offset             0 0 0
+ACS_Z1_3.TriggerThreshold   80.0
+ACS_Z1_3.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z1_3.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z1_3.NoiseThresholdEqualsTriggerThreshold true
 
-BGO_Coinc_bottom5.Named ACS_Z0_4
-ACS_Z0_4.Assign WorldVolume.ShieldedTelescope.BGObotCrystal5_ACTIVE
+Voxel3D     ACS_Z1_4
+ACS_Z1_4.DetectorVolume     BGObotCrystal10_ACTIVE
+ACS_Z1_4.SensitiveVolume    BGObotCrystal10_ACTIVE
+ACS_Z1_4.VoxelNumber        20 6 3
+ACS_Z1_4.Offset             0 0 0
+ACS_Z1_4.TriggerThreshold   80.0
+ACS_Z1_4.EnergyResolution   Gauss    0.0    0.0   10.0
+ACS_Z1_4.EnergyResolution   Gauss  100.0  100.0   10.0
+ACS_Z1_4.NoiseThresholdEqualsTriggerThreshold true
 
-Voxel3D     BGO_Coinc_bottom6
-BGO_Coinc_bottom6.DetectorVolume     BGObotCrystal6_ACTIVE
-BGO_Coinc_bottom6.SensitiveVolume    BGObotCrystal6_ACTIVE
-BGO_Coinc_bottom6.VoxelNumber        20 8 3
-BGO_Coinc_bottom6.Offset             0 0 0
-BGO_Coinc_bottom6.TriggerThreshold   80.0
-BGO_Coinc_bottom6.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom6.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom6.NoiseThresholdEqualsTriggerThreshold true
-
-BGO_Coinc_bottom6.Named ACS_Z1_0
-ACS_Z1_0.Assign WorldVolume.ShieldedTelescope.BGObotCrystal6_ACTIVE
-
-Voxel3D     BGO_Coinc_bottom7
-BGO_Coinc_bottom7.DetectorVolume     BGObotCrystal7_ACTIVE
-BGO_Coinc_bottom7.SensitiveVolume    BGObotCrystal7_ACTIVE
-BGO_Coinc_bottom7.VoxelNumber        17 6 3
-BGO_Coinc_bottom7.Offset             0 0 0
-BGO_Coinc_bottom7.TriggerThreshold   80.0
-BGO_Coinc_bottom7.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom7.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom7.NoiseThresholdEqualsTriggerThreshold true
-
-BGO_Coinc_bottom7.Named ACS_Z1_1
-ACS_Z1_1.Assign WorldVolume.ShieldedTelescope.BGObotCrystal7_ACTIVE
-
-Voxel3D     BGO_Coinc_bottom8
-BGO_Coinc_bottom8.DetectorVolume     BGObotCrystal8_ACTIVE
-BGO_Coinc_bottom8.SensitiveVolume    BGObotCrystal8_ACTIVE
-BGO_Coinc_bottom8.VoxelNumber        17 6 3
-BGO_Coinc_bottom8.Offset             0 0 0
-BGO_Coinc_bottom8.TriggerThreshold   80.0
-BGO_Coinc_bottom8.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom8.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom8.NoiseThresholdEqualsTriggerThreshold true
-
-BGO_Coinc_bottom8.Named ACS_Z1_2
-ACS_Z1_2.Assign WorldVolume.ShieldedTelescope.BGObotCrystal8_ACTIVE
-
-Voxel3D     BGO_Coinc_bottom9
-BGO_Coinc_bottom9.DetectorVolume     BGObotCrystal9_ACTIVE
-BGO_Coinc_bottom9.SensitiveVolume    BGObotCrystal9_ACTIVE
-BGO_Coinc_bottom9.VoxelNumber        20 6 3
-BGO_Coinc_bottom9.Offset             0 0 0
-BGO_Coinc_bottom9.TriggerThreshold   80.0
-BGO_Coinc_bottom9.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom9.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom9.NoiseThresholdEqualsTriggerThreshold true
-
-BGO_Coinc_bottom9.Named ACS_Z1_3
-ACS_Z1_3.Assign WorldVolume.ShieldedTelescope.BGObotCrystal9_ACTIVE
-
-Voxel3D     BGO_Coinc_bottom10
-BGO_Coinc_bottom10.DetectorVolume     BGObotCrystal10_ACTIVE
-BGO_Coinc_bottom10.SensitiveVolume    BGObotCrystal10_ACTIVE
-BGO_Coinc_bottom10.VoxelNumber        20 6 3
-BGO_Coinc_bottom10.Offset             0 0 0
-BGO_Coinc_bottom10.TriggerThreshold   80.0
-BGO_Coinc_bottom10.EnergyResolution   Gauss    0.0    0.0   10.0
-BGO_Coinc_bottom10.EnergyResolution   Gauss  100.0  100.0   10.0
-BGO_Coinc_bottom10.NoiseThresholdEqualsTriggerThreshold true
-
-BGO_Coinc_bottom10.Named ACS_Z1_4
-ACS_Z1_4.Assign WorldVolume.ShieldedTelescope.BGObotCrystal10_ACTIVE
 
 Voxel3D     BGO_Coinc_sideX
 BGO_Coinc_sideX.DetectorVolume     BGOsideX_ACTIVE
@@ -211,52 +182,52 @@ ACS_Y0_0.Assign WorldVolume.ShieldedTelescope.BGOsidenegY_ACTIVE3
 Trigger BgoVeto_bottom1
 BgoVeto_bottom1.Veto false
 BgoVeto_bottom1.TriggerByDetector true
-BgoVeto_bottom1.Detector BGO_Coinc_bottom1 1
+BgoVeto_bottom1.Detector ACS_Z0_0 1
 
 Trigger BgoVeto_bottom2
 BgoVeto_bottom2.Veto false
 BgoVeto_bottom2.TriggerByDetector true
-BgoVeto_bottom2.Detector BGO_Coinc_bottom2 1
+BgoVeto_bottom2.Detector ACS_Z0_1 1
 
 Trigger BgoVeto_bottom3
 BgoVeto_bottom3.Veto false
 BgoVeto_bottom3.TriggerByDetector true
-BgoVeto_bottom3.Detector BGO_Coinc_bottom3 1
+BgoVeto_bottom3.Detector ACS_Z0_2 1
 
 Trigger BgoVeto_bottom4
 BgoVeto_bottom4.Veto false
 BgoVeto_bottom4.TriggerByDetector true
-BgoVeto_bottom4.Detector BGO_Coinc_bottom4 1
+BgoVeto_bottom4.Detector ACS_Z0_3 1
 
 Trigger BgoVeto_bottom5
 BgoVeto_bottom5.Veto false
 BgoVeto_bottom5.TriggerByDetector true
-BgoVeto_bottom5.Detector BGO_Coinc_bottom5 1
+BgoVeto_bottom5.Detector ACS_Z0_4 1
 
 Trigger BgoVeto_bottom6
 BgoVeto_bottom6.Veto false
 BgoVeto_bottom6.TriggerByDetector true
-BgoVeto_bottom6.Detector BGO_Coinc_bottom6 1
+BgoVeto_bottom6.Detector ACS_Z1_0 1
 
 Trigger BgoVeto_bottom7
 BgoVeto_bottom7.Veto false
 BgoVeto_bottom7.TriggerByDetector true
-BgoVeto_bottom7.Detector BGO_Coinc_bottom7 1
+BgoVeto_bottom7.Detector ACS_Z1_1 1
 
 Trigger BgoVeto_bottom8
 BgoVeto_bottom8.Veto false
 BgoVeto_bottom8.TriggerByDetector true
-BgoVeto_bottom8.Detector BGO_Coinc_bottom8 1
+BgoVeto_bottom8.Detector ACS_Z1_2 1
 
 Trigger BgoVeto_bottom9
 BgoVeto_bottom9.Veto false
 BgoVeto_bottom9.TriggerByDetector true
-BgoVeto_bottom9.Detector BGO_Coinc_bottom9 1
+BgoVeto_bottom9.Detector ACS_Z1_3 1
 
 Trigger BgoVeto_bottom10
 BgoVeto_bottom10.Veto false
 BgoVeto_bottom10.TriggerByDetector true
-BgoVeto_bottom10.Detector BGO_Coinc_bottom10 1
+BgoVeto_bottom10.Detector ACS_Z1_4 1
 
 
 

--- a/COSISMEX.BGO_activated.det
+++ b/COSISMEX.BGO_activated.det
@@ -135,8 +135,8 @@ BGO_Coinc_sideX_neg.NoiseThresholdEqualsTriggerThreshold true
 BGO_Coinc_sideX_neg.Named ACS_X0_0
 ACS_X0_0.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE1
 
-BGO_Coinc_sideX_neg.Named ACS_X1_1
-ACS_X1_1.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE2
+BGO_Coinc_sideX_neg.Named ACS_X0_1
+ACS_X0_1.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE2
 
 BGO_Coinc_sideX_neg.Named ACS_X0_2
 ACS_X0_2.Assign WorldVolume.ShieldedTelescope.BGOsideXneg_ACTIVE3
@@ -158,7 +158,7 @@ BGO_Coinc_sideY.Named ACS_Y1_1
 ACS_Y1_1.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE2
 
 BGO_Coinc_sideY.Named ACS_Y1_0
-BGO_Coinc_sideY_3.ACS_Y1_0 WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE3
+ACS_Y1_0.Assign WorldVolume.ShieldedTelescope.BGOsideY_ACTIVE3
 
 Voxel3D     BGO_Coinc_sideY_neg
 BGO_Coinc_sideY_neg.DetectorVolume     BGOsideYneg_ACTIVE

--- a/COSISMEX.ClassicDEE.geo.setup
+++ b/COSISMEX.ClassicDEE.geo.setup
@@ -1,6 +1,6 @@
 
 Name COSI-SMEX 
-Version 21
+Version 22
 
 
 # You have to correct this surounding sphere:

--- a/COSISMEX.Cryostat.geo
+++ b/COSISMEX.Cryostat.geo
@@ -605,43 +605,6 @@ For Z  NLayers  { DetZPos }  {2.5660}
 
 Done
 
-D1.Named GeD_15
-GeD_15.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_a_D1_GeWafer
-D1.Named GeD_14
-GeD_14.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_a_D1_GeWafer
-D1.Named GeD_13
-GeD_13.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_a_D1_GeWafer
-D1.Named GeD_12
-GeD_12.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_a_D1_GeWafer
-
-D1.Named GeD_11
-GeD_11.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_b_D1_GeWafer
-D1.Named GeD_10
-GeD_10.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_b_D1_GeWafer
-D1.Named GeD_9
-GeD_9.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_b_D1_GeWafer
-D1.Named GeD_8
-GeD_8.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_b_D1_GeWafer
-
-D1.Named GeD_3
-GeD_3.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_c_D1_GeWafer
-D1.Named GeD_2
-GeD_2.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_c_D1_GeWafer
-D1.Named GeD_1
-GeD_1.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_c_D1_GeWafer
-D1.Named GeD_0
-GeD_0.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_c_D1_GeWafer
-
-D1.Named GeD_7
-GeD_7.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_d_D1_GeWafer
-D1.Named GeD_6
-GeD_6.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_d_D1_GeWafer
-D1.Named GeD_5
-GeD_5.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_d_D1_GeWafer
-D1.Named GeD_4
-GeD_4.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_d_D1_GeWafer
-
-
 ##########################################################
 ## IR shields
 # Updated by Alyson Joens on 03/04/23

--- a/COSISMEX.Cryostat.geo
+++ b/COSISMEX.Cryostat.geo
@@ -588,36 +588,58 @@ For Z  NLayers  { DetZPos }  {2.5660}
    SingleDetector_Copy%Z_a.Rotation 0.0 0.0 180.0
    SingleDetector_Copy%Z_a.Position {DetX + DetXHalfGap} {DetY+DetYHalfGap} {$Z}
 
-   D1.Named D1_Copy%Z_a
-   D1_Copy%Z_a.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_a_D1_GeWafer
-
    SingleDetector.Copy SingleDetector_Copy%Z_b
    SingleDetector_Copy%Z_b.Mother Cryostat_Interior
    SingleDetector_Copy%Z_b.Rotation 180.0 0.0 180.0
    SingleDetector_Copy%Z_b.Position {DetX + DetXHalfGap} {-(DetY+DetYHalfGap)} {$Z}
-
-   D1.Named D1_Copy%Z_b
-   D1_Copy%Z_b.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_b_D1_GeWafer
 
    SingleDetector.Copy SingleDetector_Copy%Z_c
    SingleDetector_Copy%Z_c.Mother Cryostat_Interior
    SingleDetector_Copy%Z_c.Rotation 180.0 0.0 0.0
    SingleDetector_Copy%Z_c.Position {-DetX - DetXHalfGap} {DetY+DetYHalfGap} {$Z}
 
-   D1.Named D1_Copy%Z_c
-   D1_Copy%Z_c.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_c_D1_GeWafer
-
    SingleDetector.Copy SingleDetector_Copy%Z_d
    SingleDetector_Copy%Z_d.Mother Cryostat_Interior
    SingleDetector_Copy%Z_d.Rotation 0.0 0.0 0.0
    SingleDetector_Copy%Z_d.Position {-DetX-DetXHalfGap} {-(DetY+DetYHalfGap)} {$Z}
 
-   D1.Named D1_Copy%Z_d
-   D1_Copy%Z_d.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_d_D1_GeWafer
 Done
 
+D1.Named GeD_15
+GeD_15.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_a_D1_GeWafer
+D1.Named GeD_14
+GeD_14.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_a_D1_GeWafer
+D1.Named GeD_13
+GeD_13.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_a_D1_GeWafer
+D1.Named GeD_12
+GeD_12.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_a_D1_GeWafer
 
+D1.Named GeD_11
+GeD_11.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_b_D1_GeWafer
+D1.Named GeD_10
+GeD_10.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_b_D1_GeWafer
+D1.Named GeD_9
+GeD_9.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_b_D1_GeWafer
+D1.Named GeD_8
+GeD_8.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_b_D1_GeWafer
 
+D1.Named GeD_3
+GeD_3.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_c_D1_GeWafer
+D1.Named GeD_2
+GeD_2.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_c_D1_GeWafer
+D1.Named GeD_1
+GeD_1.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_c_D1_GeWafer
+D1.Named GeD_0
+GeD_0.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_c_D1_GeWafer
+
+D1.Named GeD_7
+GeD_7.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy1_d_D1_GeWafer
+D1.Named GeD_6
+GeD_6.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy2_d_D1_GeWafer
+D1.Named GeD_5
+GeD_5.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy3_d_D1_GeWafer
+D1.Named GeD_4
+GeD_4.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy4_d_D1_GeWafer
 
 
 ##########################################################

--- a/COSISMEX.Cryostat.geo
+++ b/COSISMEX.Cryostat.geo
@@ -582,7 +582,6 @@ Bellville_Assem.Mother Cryostat_Interior
 Constant DetDepth {(-CryostatOuterZ - CryoLidZ - CryoBaseStageZ)-15}
 
 For Z  NLayers  { DetZPos }  {2.5660}
-
    SingleDetector.Copy SingleDetector_Copy%Z_a
    SingleDetector_Copy%Z_a.Mother Cryostat_Interior
    SingleDetector_Copy%Z_a.Rotation 0.0 0.0 180.0
@@ -602,8 +601,10 @@ For Z  NLayers  { DetZPos }  {2.5660}
    SingleDetector_Copy%Z_d.Mother Cryostat_Interior
    SingleDetector_Copy%Z_d.Rotation 0.0 0.0 0.0
    SingleDetector_Copy%Z_d.Position {-DetX-DetXHalfGap} {-(DetY+DetYHalfGap)} {$Z}
-
 Done
+
+
+
 
 ##########################################################
 ## IR shields
@@ -1030,3 +1031,5 @@ Flexure4.Mother Cryostat_Interior
 
 
 #moved the Ribbon Cable Guards to the ACS model
+
+

--- a/COSISMEX.Cryostat.geo
+++ b/COSISMEX.Cryostat.geo
@@ -582,26 +582,40 @@ Bellville_Assem.Mother Cryostat_Interior
 Constant DetDepth {(-CryostatOuterZ - CryoLidZ - CryoBaseStageZ)-15}
 
 For Z  NLayers  { DetZPos }  {2.5660}
+
    SingleDetector.Copy SingleDetector_Copy%Z_a
    SingleDetector_Copy%Z_a.Mother Cryostat_Interior
    SingleDetector_Copy%Z_a.Rotation 0.0 0.0 180.0
    SingleDetector_Copy%Z_a.Position {DetX + DetXHalfGap} {DetY+DetYHalfGap} {$Z}
+
+   D1.Named D1_Copy%Z_a
+   D1_Copy%Z_a.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_a_D1_GeWafer
 
    SingleDetector.Copy SingleDetector_Copy%Z_b
    SingleDetector_Copy%Z_b.Mother Cryostat_Interior
    SingleDetector_Copy%Z_b.Rotation 180.0 0.0 180.0
    SingleDetector_Copy%Z_b.Position {DetX + DetXHalfGap} {-(DetY+DetYHalfGap)} {$Z}
 
+   D1.Named D1_Copy%Z_b
+   D1_Copy%Z_b.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_b_D1_GeWafer
+
    SingleDetector.Copy SingleDetector_Copy%Z_c
    SingleDetector_Copy%Z_c.Mother Cryostat_Interior
    SingleDetector_Copy%Z_c.Rotation 180.0 0.0 0.0
    SingleDetector_Copy%Z_c.Position {-DetX - DetXHalfGap} {DetY+DetYHalfGap} {$Z}
 
+   D1.Named D1_Copy%Z_c
+   D1_Copy%Z_c.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_c_D1_GeWafer
+
    SingleDetector.Copy SingleDetector_Copy%Z_d
    SingleDetector_Copy%Z_d.Mother Cryostat_Interior
    SingleDetector_Copy%Z_d.Rotation 0.0 0.0 0.0
    SingleDetector_Copy%Z_d.Position {-DetX-DetXHalfGap} {-(DetY+DetYHalfGap)} {$Z}
+
+   D1.Named D1_Copy%Z_d
+   D1_Copy%Z_d.Assign WorldVolume.ShieldedTelescope.Telescope.Cryostat_Interior.SingleDetector_Copy%Z_d_D1_GeWafer
 Done
+
 
 
 
@@ -1031,5 +1045,3 @@ Flexure4.Mother Cryostat_Interior
 
 
 #moved the Ribbon Cable Guards to the ACS model
-
-

--- a/COSISMEX.analysis.geo.setup
+++ b/COSISMEX.analysis.geo.setup
@@ -1,6 +1,6 @@
 
 Name COSI-SMEX 
-Version 21
+Version 22
 
 
 # You have to correct this surounding sphere:

--- a/COSISMEX.analysis_BGOreading.geo.setup
+++ b/COSISMEX.analysis_BGOreading.geo.setup
@@ -1,6 +1,6 @@
 
 Name COSI-SMEX 
-Version 21
+Version 22
 
 
 # You have to correct this surounding sphere:

--- a/COSISMEX.sim.geo.setup
+++ b/COSISMEX.sim.geo.setup
@@ -1,6 +1,6 @@
 
 Name COSI-SMEX 
-Version 21
+Version 22
 
 
 # You have to correct this surounding sphere:

--- a/COSISMEX.sim_BGOreading.geo.setup
+++ b/COSISMEX.sim_BGOreading.geo.setup
@@ -1,6 +1,6 @@
 
 Name COSI-SMEX 
-Version 21
+Version 22
 
 
 # You have to correct this surounding sphere:


### PR DESCRIPTION
This PR adds the named detectors for BGO crystals. 

This is needed to obtain the counts of each module with the MEGAlib python wrapper and to use the bc-tools IRF generator. 